### PR TITLE
Have metropolis footer example use orange left and right

### DIFF
--- a/docs-src/examples/embedded/appearance/metropolis-footer.typ
+++ b/docs-src/examples/embedded/appearance/metropolis-footer.typ
@@ -12,9 +12,9 @@
     "footer",
     // the footer cell has default content that will appear on every slide using that layout
     content: [
-      Mosaic                     // text
-      #h(1fr)                    // space
-      #m.components.progress()   // slide number
+      #text(fill: orange, "Mosaic")	// text in orange accent color
+      #h(1fr)                    	// space
+      #m.components.progress()   	// slide number
     ],
   )),
 )


### PR DESCRIPTION
This is the micro-pull request I had promised to align the colour on the left-hand side of the case study with the one on the right-hand side (which already uses 'orange' aka the accent).

Best I could do here was to refer to 'orange', somehow I did not get the 'accent' out for use.  You also will need to update the pdf file the website show but maybe your CI does that automagically ...